### PR TITLE
Allow processing to continue on topic message failure

### DIFF
--- a/src/Equinor.ProCoSys.BusSender.Core/Interfaces/IUnitOfWork.cs
+++ b/src/Equinor.ProCoSys.BusSender.Core/Interfaces/IUnitOfWork.cs
@@ -5,4 +5,6 @@ namespace Equinor.ProCoSys.BusSenderWorker.Core.Interfaces;
 public interface IUnitOfWork
 {
     Task<int> SaveChangesAsync();
+
+    void ClearChangeTracker();
 }

--- a/src/Equinor.ProCoSys.BusSender.Infrastructure/Data/BusSenderServiceContext.cs
+++ b/src/Equinor.ProCoSys.BusSender.Infrastructure/Data/BusSenderServiceContext.cs
@@ -21,6 +21,8 @@ public class BusSenderServiceContext : DbContext, IUnitOfWork
 
     public Task<int> SaveChangesAsync() => base.SaveChangesAsync();
 
+    public void ClearChangeTracker() => base.ChangeTracker.Clear();
+
     public virtual DbSet<BusEvent> BusEvents { get; set; } = null!;
 
 


### PR DESCRIPTION
Updated how we send batches of topic messages, such that if there is a problem with one topic, we will skip over it and work on the next one instead of doing a full stop of the entire process