### PR TITLE
GH01676: Execute tag topic query in one go for all tags in chunk

### DIFF
--- a/src/Equinor.ProCoSys.BusSender.Core/Interfaces/IBusEventService.cs
+++ b/src/Equinor.ProCoSys.BusSender.Core/Interfaces/IBusEventService.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.IO;
 using System.Threading.Tasks;
 using Equinor.ProCoSys.BusSenderWorker.Core.Models;
 

--- a/src/Equinor.ProCoSys.BusSender.Core/Interfaces/IBusEventService.cs
+++ b/src/Equinor.ProCoSys.BusSender.Core/Interfaces/IBusEventService.cs
@@ -1,11 +1,14 @@
-﻿using System.IO;
+﻿using System.Collections.Generic;
+using System.IO;
 using System.Threading.Tasks;
+using Equinor.ProCoSys.BusSenderWorker.Core.Models;
 
 namespace Equinor.ProCoSys.BusSenderWorker.Core.Interfaces;
 
 public interface IBusEventService
 {
     Task<string> AttachTagDetails(string? tagMessage);
+    Task AttachTagDetails(List<BusEvent> busEvent);
     Task<string?> CreateActionMessage(string busEventMessage);
     Task<string?> CreateCallOffMessage(string busEventMessage);
     Task<string?> CreateChecklistMessage(string busEventMessage);

--- a/src/Equinor.ProCoSys.BusSender.Core/Interfaces/IBusEventService.cs
+++ b/src/Equinor.ProCoSys.BusSender.Core/Interfaces/IBusEventService.cs
@@ -6,7 +6,7 @@ namespace Equinor.ProCoSys.BusSenderWorker.Core.Interfaces;
 
 public interface IBusEventService
 {
-    Task<string> AttachTagDetails(string? tagMessage);
+    Task AttachTagDetails(BusEvent busEvent);
     Task AttachTagDetails(List<BusEvent> busEvent);
     Task<string?> CreateActionMessage(string busEventMessage);
     Task<string?> CreateCallOffMessage(string busEventMessage);

--- a/src/Equinor.ProCoSys.BusSender.Core/Interfaces/ITagDetailsRepository.cs
+++ b/src/Equinor.ProCoSys.BusSender.Core/Interfaces/ITagDetailsRepository.cs
@@ -1,8 +1,10 @@
-﻿using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace Equinor.ProCoSys.BusSenderWorker.Core.Interfaces;
 
 public interface ITagDetailsRepository
 {
     public Task<string> GetDetailsStringByTagId(long tagId);
+    public Task<Dictionary<long, string>> GetDetailsListByTagId(IEnumerable<long> tagIds);
 }

--- a/src/Equinor.ProCoSys.BusSender.Core/Interfaces/ITagDetailsRepository.cs
+++ b/src/Equinor.ProCoSys.BusSender.Core/Interfaces/ITagDetailsRepository.cs
@@ -6,5 +6,5 @@ namespace Equinor.ProCoSys.BusSenderWorker.Core.Interfaces;
 public interface ITagDetailsRepository
 {
     public Task<string> GetDetailsStringByTagId(long tagId);
-    public Task<Dictionary<long, string>> GetDetailsListByTagId(IEnumerable<long> tagIds);
+    public Task<Dictionary<long, string>> GetDetailsByTagId(IEnumerable<long> tagIds);
 }

--- a/src/Equinor.ProCoSys.BusSender.Core/Interfaces/ITagDetailsRepository.cs
+++ b/src/Equinor.ProCoSys.BusSender.Core/Interfaces/ITagDetailsRepository.cs
@@ -5,6 +5,5 @@ namespace Equinor.ProCoSys.BusSenderWorker.Core.Interfaces;
 
 public interface ITagDetailsRepository
 {
-    public Task<string> GetDetailsStringByTagId(long tagId);
     public Task<Dictionary<long, string>> GetDetailsByTagId(IEnumerable<long> tagIds);
 }

--- a/src/Equinor.ProCoSys.BusSender.Core/Services/BusEventService.cs
+++ b/src/Equinor.ProCoSys.BusSender.Core/Services/BusEventService.cs
@@ -30,7 +30,7 @@ public class BusEventService : IBusEventService
             JsonSerializer.Deserialize<TagTopic>(WashString(tagMessage) ?? throw new InvalidOperationException());
         if (tagTopic?.TagId == null || !long.TryParse(tagTopic.TagId, out var tagId))
         {
-            throw new Exception("Could not deserialize TagTopic");
+            throw new Exception($"Could not deserialize TagTopic. TagId: {tagTopic?.TagId}");
         }
 
         tagTopic.TagDetails = WashString(await _tagDetailsRepository.GetDetailsStringByTagId(tagId));
@@ -48,7 +48,7 @@ public class BusEventService : IBusEventService
         {
             if (x?.TagId == null || !long.TryParse(x.TagId, out var tagId))
             {
-                throw new Exception("Could not deserialize TagTopic");
+                throw new Exception($"Could not deserialize TagTopic. {x?.TagId}");
             }
             return tagId;
         });
@@ -59,7 +59,7 @@ public class BusEventService : IBusEventService
         {
             if (!tagTopicsDictionary.TryGetValue(busEvent.Id, out var tagTopic) || tagTopic?.TagId == null || !long.TryParse(tagTopic.TagId, out var tagId))
             {
-                throw new Exception("Could not retrieve TagTopic from BusEvent");
+                throw new Exception($"Could not retrieve TagTopic from BusEvent. BusEvent.Id: {busEvent.Id}");
             }
 
             tagTopic.TagDetails = tagDetailsDictionary.TryGetValue(tagId, out var details) ? WashString(details) : string.Empty;

--- a/src/Equinor.ProCoSys.BusSender.Core/Services/BusEventService.cs
+++ b/src/Equinor.ProCoSys.BusSender.Core/Services/BusEventService.cs
@@ -59,7 +59,11 @@ public class BusEventService : IBusEventService
                 throw new Exception($"Could not deserialize TagTopic. {x?.TagId}");
             }
             return tagId;
-        });
+        }).Distinct();
+        // There could be multiple updates for the same tagId within a short time span.
+        // For simple messages duplicates are filtered out, but this is not the case for thick messages like this.
+        // We only need to fetch the tag details once for each tagId when handled within the same loop.
+        // Hence the use of distinct here.
 
         return await _tagDetailsRepository.GetDetailsListByTagId(tagIds);
     }

--- a/src/Equinor.ProCoSys.BusSender.Core/Services/BusEventService.cs
+++ b/src/Equinor.ProCoSys.BusSender.Core/Services/BusEventService.cs
@@ -24,7 +24,7 @@ public class BusEventService : IBusEventService
         _eventRepository = eventRepository;
     }
 
-    public virtual async Task<string> AttachTagDetails(string? tagMessage)
+    public async Task<string> AttachTagDetails(string? tagMessage)
     {
         var tagTopic =
             JsonSerializer.Deserialize<TagTopic>(WashString(tagMessage) ?? throw new InvalidOperationException());

--- a/src/Equinor.ProCoSys.BusSender.Core/Services/BusEventService.cs
+++ b/src/Equinor.ProCoSys.BusSender.Core/Services/BusEventService.cs
@@ -65,7 +65,7 @@ public class BusEventService : IBusEventService
         // We only need to fetch the tag details once for each tagId when handled within the same loop.
         // Hence the use of distinct here.
 
-        return await _tagDetailsRepository.GetDetailsListByTagId(tagIds);
+        return await _tagDetailsRepository.GetDetailsByTagId(tagIds);
     }
 
     private void UpdateBusEventsWithTagDetails(List<BusEvent> busEvents, List<TagTopic> tagTopics, Dictionary<long, string> tagDetailsDictionary)

--- a/src/Equinor.ProCoSys.BusSender.Core/Services/BusEventService.cs
+++ b/src/Equinor.ProCoSys.BusSender.Core/Services/BusEventService.cs
@@ -24,7 +24,7 @@ public class BusEventService : IBusEventService
         _eventRepository = eventRepository;
     }
 
-    public async Task<string> AttachTagDetails(string? tagMessage)
+    public virtual async Task<string> AttachTagDetails(string? tagMessage)
     {
         var tagTopic =
             JsonSerializer.Deserialize<TagTopic>(WashString(tagMessage) ?? throw new InvalidOperationException());
@@ -53,8 +53,7 @@ public class BusEventService : IBusEventService
             .Distinct()
             .ToArray();
 
-        var tagDetailsDictionary = await _tagDetailsRepository.GetDetailsListByTagId(tagIds)
-            ?? throw new Exception("DetailsList is null.");
+        var tagDetailsDictionary = await _tagDetailsRepository.GetDetailsListByTagId(tagIds);
 
         foreach (var busEvent in busEvents)
         {
@@ -64,7 +63,7 @@ public class BusEventService : IBusEventService
                 throw new Exception("Could not deserialize TagTopic");
             }
 
-            tagTopic.TagDetails = tagDetailsDictionary.TryGetValue(tagId, out var details) ? details : string.Empty;
+            tagTopic.TagDetails = tagDetailsDictionary.TryGetValue(tagId, out var details) ? WashString(details) : string.Empty;
             busEvent.Message = JsonSerializer.Serialize(tagTopic);
         }
     }

--- a/src/Equinor.ProCoSys.BusSender.Core/Services/BusSenderService.cs
+++ b/src/Equinor.ProCoSys.BusSender.Core/Services/BusSenderService.cs
@@ -195,7 +195,7 @@ public class BusSenderService : IBusSenderService
             await UpdateEventsBasedOnTagTopic(unProcessedEvents);
         }
 
-        _logger.LogInformation("Update loop finished at at {Sw} ms", dsw.ElapsedMilliseconds);
+        _logger.LogInformation("Update loop finished at {Sw} ms", dsw.ElapsedMilliseconds);
         await _unitOfWork.SaveChangesAsync();
 
 

--- a/src/Equinor.ProCoSys.BusSender.Core/Services/BusSenderService.cs
+++ b/src/Equinor.ProCoSys.BusSender.Core/Services/BusSenderService.cs
@@ -81,7 +81,7 @@ public class BusSenderService : IBusSenderService
         _telemetryClient.Flush();
     }
 
-    private async Task BatchAndSendPerTopic(List<(string Key, Queue<BusEvent> messages)> eventGroups)
+    public virtual async Task BatchAndSendPerTopic(List<(string Key, Queue<BusEvent> messages)> eventGroups)
     {
         foreach (var (topic, messages) in eventGroups)
         {
@@ -183,7 +183,8 @@ public class BusSenderService : IBusSenderService
         _logger.LogInformation("Amount of messages to process: {Count} ", unProcessedEvents.Count);
 
         var isOverInOperatorLimit = unProcessedEvents.Count >= 1000;
-        if (unProcessedEvents.Any(e => e.Event != TagTopic.TopicName) || isOverInOperatorLimit) { 
+        if (unProcessedEvents.Any(e => e.Event != TagTopic.TopicName) || isOverInOperatorLimit) 
+        { 
             foreach (var simpleUnprocessedBusEvent in unProcessedEvents.Where(e =>
                                 IsSimpleMessage(e) || e.Event == TagTopic.TopicName))
                 {
@@ -259,16 +260,16 @@ public class BusSenderService : IBusSenderService
 
     private async Task UpdateEventsBasedOnTagTopic(List<BusEvent> busEvents)
     {
-
+        if (busEvents.Any(e => e.Event != TagTopic.TopicName))
+        {
+            return;
+        }
 
         _logger.LogDebug("Started update for tag topic bus events");
         var sw = Stopwatch.StartNew();
         await _service.AttachTagDetails(busEvents);
-
         _logger.LogDebug("Update for tag topic bus events took {Ms} ms", sw.ElapsedMilliseconds);
         sw.Stop();
-
-
     }
 
     private async Task UpdateEventBasedOnTopic(BusEvent busEvent)

--- a/src/Equinor.ProCoSys.BusSender.Core/Services/BusSenderService.cs
+++ b/src/Equinor.ProCoSys.BusSender.Core/Services/BusSenderService.cs
@@ -291,7 +291,7 @@ public class BusSenderService : IBusSenderService
                 }
             case TagTopic.TopicName:
                 {
-                    busEvent.Message = await _service.AttachTagDetails(busEvent.Message);
+                    await _service.AttachTagDetails(busEvent);
                     break;
                 }
             case "checklist":

--- a/src/Equinor.ProCoSys.BusSender.Core/Services/BusSenderService.cs
+++ b/src/Equinor.ProCoSys.BusSender.Core/Services/BusSenderService.cs
@@ -81,7 +81,7 @@ public class BusSenderService : IBusSenderService
         _telemetryClient.Flush();
     }
 
-    public virtual async Task BatchAndSendPerTopic(List<(string Key, Queue<BusEvent> messages)> eventGroups)
+    private async Task BatchAndSendPerTopic(List<(string Key, Queue<BusEvent> messages)> eventGroups)
     {
         foreach (var (topic, messages) in eventGroups)
         {

--- a/src/Equinor.ProCoSys.BusSender.Core/Services/BusSenderService.cs
+++ b/src/Equinor.ProCoSys.BusSender.Core/Services/BusSenderService.cs
@@ -262,7 +262,7 @@ public class BusSenderService : IBusSenderService
     {
         if (busEvents.Any(e => e.Event != TagTopic.TopicName))
         {
-            return;
+            throw new InvalidOperationException("This method can be used by TagTopic Events only.");
         }
 
         _logger.LogDebug("Started update for tag topic bus events");

--- a/src/Equinor.ProCoSys.BusSender.Infrastructure/Repositories/TagDetailsRepository.cs
+++ b/src/Equinor.ProCoSys.BusSender.Infrastructure/Repositories/TagDetailsRepository.cs
@@ -68,7 +68,7 @@ public class TagDetailsRepository : ITagDetailsRepository
     }
 
 
-    public async Task<Dictionary<long, string>> GetDetailsListByTagId(IEnumerable<long> tagIds)
+    public async Task<Dictionary<long, string>> GetDetailsByTagId(IEnumerable<long> tagIds)
     {
         var dbConnection = _context.Database.GetDbConnection();
         var connectionWasClosed = dbConnection.State != ConnectionState.Open;

--- a/src/Equinor.ProCoSys.BusSender.Infrastructure/Repositories/TagDetailsRepository.cs
+++ b/src/Equinor.ProCoSys.BusSender.Infrastructure/Repositories/TagDetailsRepository.cs
@@ -47,7 +47,7 @@ public class TagDetailsRepository : ITagDetailsRepository
                 return "{}";
             }
 
-            var tagDetails = (string)result[0];
+            var tagDetails = result[0].ToString();
 
             if (await result.ReadAsync())
             {

--- a/src/Equinor.ProCoSys.BusSender.Infrastructure/Repositories/TagDetailsRepository.cs
+++ b/src/Equinor.ProCoSys.BusSender.Infrastructure/Repositories/TagDetailsRepository.cs
@@ -91,17 +91,13 @@ public class TagDetailsRepository : ITagDetailsRepository
 
             var tagDetailsDictionary = new Dictionary<long, string>();
 
-            if (await result.ReadAsync())
-            {
-                if (result[0] is not DBNull)
-                {
-                    var firstTagId = result.GetInt64(0);
-                    var firstTagDetails = result.GetString(1);
-                    tagDetailsDictionary[firstTagId] = firstTagDetails;
-                }
-            }
             while (await result.ReadAsync())
             {
+                if (result[0] is DBNull)
+                {
+                    continue;
+                }
+
                 var tagId = result.GetInt64(0);
                 var tagDetails = result.GetString(1);
                 tagDetailsDictionary[tagId] = tagDetails;

--- a/src/Equinor.ProCoSys.BusSender.Infrastructure/Repositories/TagDetailsRepository.cs
+++ b/src/Equinor.ProCoSys.BusSender.Infrastructure/Repositories/TagDetailsRepository.cs
@@ -89,12 +89,17 @@ public class TagDetailsRepository : ITagDetailsRepository
                 return new Dictionary<long, string>();
             }
 
-            if (!await result.ReadAsync() || result[0] is DBNull)
-            {
-                return new Dictionary<long, string>();
-            }
-
             var tagDetailsDictionary = new Dictionary<long, string>();
+
+            if (await result.ReadAsync())
+            {
+                if (result[0] is not DBNull)
+                {
+                    var firstTagId = result.GetInt64(0);
+                    var firstTagDetails = result.GetString(1);
+                    tagDetailsDictionary[firstTagId] = firstTagDetails;
+                }
+            }
             while (await result.ReadAsync())
             {
                 var tagId = result.GetInt64(0);

--- a/src/Equinor.ProCoSys.BusSender.Infrastructure/Repositories/TagDetailsRepository.cs
+++ b/src/Equinor.ProCoSys.BusSender.Infrastructure/Repositories/TagDetailsRepository.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Data;
 using System.Threading.Tasks;
 using Equinor.ProCoSys.BusSenderWorker.Core.Interfaces;
@@ -31,7 +32,7 @@ public class TagDetailsRepository : ITagDetailsRepository
         try
         {
             await using var command = _context.Database.GetDbConnection().CreateCommand();
-            command.CommandText = GetTagDetailsQuery(tagId);
+            command.CommandText = GetTagDetailsQuery([tagId]);
 
             await using var result = await command.ExecuteReaderAsync();
 
@@ -65,15 +66,64 @@ public class TagDetailsRepository : ITagDetailsRepository
         }
     }
 
-    private static string GetTagDetailsQuery(long tagId) =>
+
+    public async Task<Dictionary<long, string>> GetDetailsListByTagId(IEnumerable<long> tagIds)
+    {
+        var dbConnection = _context.Database.GetDbConnection();
+        var connectionWasClosed = dbConnection.State != ConnectionState.Open;
+        if (connectionWasClosed)
+        {
+            await _context.Database.OpenConnectionAsync();
+        }
+
+        try
+        {
+            await using var command = _context.Database.GetDbConnection().CreateCommand();
+            command.CommandText = GetTagDetailsQuery(tagIds);
+
+            await using var result = await command.ExecuteReaderAsync();
+
+            if (!result.HasRows)
+            {
+                _logger.LogInformation("No tag details found for the provided tag IDs.");
+                return new Dictionary<long, string>();
+            }
+
+            if (!await result.ReadAsync() || result[0] is DBNull)
+            {
+                return new Dictionary<long, string>();
+            }
+
+            var tagDetailsDictionary = new Dictionary<long, string>();
+            while (await result.ReadAsync())
+            {
+                var tagId = result.GetInt64(0);
+                var tagDetails = result.GetString(1);
+                tagDetailsDictionary[tagId] = tagDetails;
+            }
+
+            return tagDetailsDictionary;
+        }
+        finally
+        {
+            // If we opened it, we have to close it.
+            if (connectionWasClosed)
+            {
+                await _context.Database.CloseConnectionAsync();
+            }
+        }
+    }
+
+    private static string GetTagDetailsQuery(IEnumerable<long> tagIds) =>
         @$"
-            select listagg('""'|| colName ||'"":""'|| regexp_replace(val, '([""\])', '\\\1') ||'""'
+            select tagId, listagg('""'|| colName ||'"":""'|| regexp_replace(val, '([""\])', '\\\1') ||'""'
             || case when colname2 is not null then ',' || '""'|| colName2 ||'"":""'|| val2 ||'""' end
             || case when colname3 is not null then ',' || '""'|| colName3 ||'"":""'|| val3 ||'""' end,
             ',')
-            within group (order by colName, colName2,colName3) as tagDetails
+            within group (order by colName, colName2, colName3) as tagDetails
             from (
                 select
+                val.element_id tagId,
                 decode(f.columnname, 'FROM_TAG_NUMBER', 'FromTagGuid', null) as colName2,
                 decode(f.columnname, 'TO_TAG_NUMBER', 'ToTagGuid', null) as colName3,
                 f.columnname as colName,
@@ -83,22 +133,24 @@ public class TagDetailsRepository : ITagDetailsRepository
                     to_char(val.valuenumber),
                     tag.tagno,
                     libval.code
-            ) as val,
-            tag.procosys_guid as val2,
-            tag.procosys_guid as val3
-            from defineelementfield def
-                left join field f on def.field_id = f.field_id
-                left join library unit on unit.library_id = f.unit_id
-                join elementfield val on (val.field_id = def.field_id and val.element_id = {tagId})
-                join tag t on t.tag_id = val.element_id 
-                left join library libval on libval.library_id = val.library_id
-                left join library reg on reg.library_id = def.register_id
-                left join tag on tag.tag_id = val.tag_id
-            where def.elementtype = 'TAG'
-            and (def.register_id is null or def.register_id = t.register_id)
-            and not def.isvoided = 'Y'
-            and f.columntype in ('NUMBER', 'DATE', 'STRING', 'LIBRARY', 'TAG')
-            and f.projectschema = t.projectschema
-            order by def.sortkey nulls first
-        )";
+                ) as val,
+                tag.procosys_guid as val2,
+                tag.procosys_guid as val3
+                from defineelementfield def
+                    left join field f on def.field_id = f.field_id
+                    left join library unit on unit.library_id = f.unit_id
+                    join elementfield val on (val.field_id = def.field_id and val.element_id IN ({string.Join(",", tagIds)}))
+                    join tag t on t.tag_id = val.element_id 
+                    left join library libval on libval.library_id = val.library_id
+                    left join library reg on reg.library_id = def.register_id
+                    left join tag on tag.tag_id = val.tag_id
+                where def.elementtype = 'TAG'
+                and (def.register_id is null or def.register_id = t.register_id)
+                and not def.isvoided = 'Y'
+                and f.columntype in ('NUMBER', 'DATE', 'STRING', 'LIBRARY', 'TAG')
+                and f.projectschema = t.projectschema
+                order by def.sortkey nulls first
+            )
+            group by tagId
+        ";
 }

--- a/src/Equinor.ProCoSys.BusSender.Infrastructure/Repositories/TagDetailsRepository.cs
+++ b/src/Equinor.ProCoSys.BusSender.Infrastructure/Repositories/TagDetailsRepository.cs
@@ -21,12 +21,6 @@ public class TagDetailsRepository : ITagDetailsRepository
         _logger = logger;
     }
 
-    public async Task<string> GetDetailsStringByTagId(long tagId)
-    {
-        var result = await GetDetailsByTagId([tagId]);
-        return result.TryGetValue(tagId, out var details) ? details : "{}";
-    }
-
     public async Task<Dictionary<long, string>> GetDetailsByTagId(IEnumerable<long> tagIds)
     {
         var dbConnection = _context.Database.GetDbConnection();
@@ -43,7 +37,13 @@ public class TagDetailsRepository : ITagDetailsRepository
             var tagDetailsDictionary = tagIds.ToDictionary(id => id, _ => "{}");
 
             await using var command = _context.Database.GetDbConnection().CreateCommand();
-            command.CommandText = GetTagDetailsQuery(tagIds);
+            if (tagIds.Count()>1) {
+                command.CommandText = GetTagDetailsQuery(tagIds);
+            }
+            else
+            {
+                command.CommandText = GetTagDetailsQuerySingle(tagIds.First());
+            }
 
             await using var result = await command.ExecuteReaderAsync();
 
@@ -116,4 +116,45 @@ public class TagDetailsRepository : ITagDetailsRepository
             )
             group by tagId
         ";
+
+    private static string GetTagDetailsQuerySingle(long tagId) =>
+        @$"
+            select tagId, listagg('""'|| colName ||'"":""'|| regexp_replace(val, '([""\])', '\\\1') ||'""'
+            || case when colname2 is not null then ',' || '""'|| colName2 ||'"":""'|| val2 ||'""' end
+            || case when colname3 is not null then ',' || '""'|| colName3 ||'"":""'|| val3 ||'""' end,
+            ',')
+            within group (order by colName, colName2, colName3) as tagDetails
+            from (
+                select
+                val.element_id tagId,
+                decode(f.columnname, 'FROM_TAG_NUMBER', 'FromTagGuid', null) as colName2,
+                decode(f.columnname, 'TO_TAG_NUMBER', 'ToTagGuid', null) as colName3,
+                f.columnname as colName,
+                coalesce(
+                    val.valuestring,
+                    to_char(val.valuedate, 'yyyy-mm-dd hh24:mi:ss'),
+                    to_char(val.valuenumber),
+                    tag.tagno,
+                    libval.code
+                ) as val,
+                tag.procosys_guid as val2,
+                tag.procosys_guid as val3
+                from defineelementfield def
+                    left join field f on def.field_id = f.field_id
+                    left join library unit on unit.library_id = f.unit_id
+                    join elementfield val on (val.field_id = def.field_id and val.element_id = {tagId})
+                    join tag t on t.tag_id = val.element_id 
+                    left join library libval on libval.library_id = val.library_id
+                    left join library reg on reg.library_id = def.register_id
+                    left join tag on tag.tag_id = val.tag_id
+                where def.elementtype = 'TAG'
+                and (def.register_id is null or def.register_id = t.register_id)
+                and not def.isvoided = 'Y'
+                and f.columntype in ('NUMBER', 'DATE', 'STRING', 'LIBRARY', 'TAG')
+                and f.projectschema = t.projectschema
+                order by def.sortkey nulls first
+            )
+            group by tagId
+        ";
+
 }

--- a/tests/Equinor.ProCoSys.BusSender.Core.Tests/BusEventServiceTests.cs
+++ b/tests/Equinor.ProCoSys.BusSender.Core.Tests/BusEventServiceTests.cs
@@ -2222,6 +2222,4 @@ public class BusEventServiceTests
         Assert.IsNotNull(deserializedTagTopic2.CommPkgGuid);
 
     }
-
-
 }

--- a/tests/Equinor.ProCoSys.BusSender.Core.Tests/BusEventServiceTests.cs
+++ b/tests/Equinor.ProCoSys.BusSender.Core.Tests/BusEventServiceTests.cs
@@ -2119,7 +2119,7 @@ public class BusEventServiceTests
             { 116866655, "Details for tag 116866655" }
         };
 
-        _tagDetailsRepositoryMock.Setup(t => t.GetDetailsListByTagId(tagDetailsDictionary.Keys))
+        _tagDetailsRepositoryMock.Setup(t => t.GetDetailsByTagId(tagDetailsDictionary.Keys))
             .ReturnsAsync(tagDetailsDictionary);
         const string jsonMessage1 =
             @"{

--- a/tests/Equinor.ProCoSys.BusSender.Core.Tests/BusSenderServiceTests.cs
+++ b/tests/Equinor.ProCoSys.BusSender.Core.Tests/BusSenderServiceTests.cs
@@ -380,29 +380,16 @@ public class BusSenderServiceTests
             });
         }
 
-        var busSenderServiceMock = new Mock<BusSenderService>(
-                _busSender,
-                _busEventRepository.Object,
-                _iUnitOfWork.Object,
-                new Mock<ILogger<BusSenderService>>().Object,
-                new Mock<ITelemetryClient>().Object,
-                _busEventServiceMock.Object,
-                _queueMonitorService.Object
-            )
-            { CallBase = true };
-
-        busSenderServiceMock
-            .Setup(service => service.BatchAndSendPerTopic(It.IsAny<List<(string Key, Queue<BusEvent> messages)>>()))
-            .Returns(Task.CompletedTask);
+        _busSender.Add("tag", _topicClientMock1.Object);
 
         _busEventRepository.Setup(b => b.GetEarliestUnProcessedEventChunk())
             .Returns(() => Task.FromResult(busEvents));
 
         _busEventServiceMock.Setup(b => b.AttachTagDetails(It.IsAny<string>()))
-            .Returns(() => Task.FromResult(It.IsAny<string>()));
+            .Returns(() => Task.FromResult("{}"));
 
         // Act
-        await busSenderServiceMock.Object.HandleBusEvents();
+        await _dut.HandleBusEvents();
 
         // Assert
         Assert.AreEqual(1001, busEvents.Count);

--- a/tests/Equinor.ProCoSys.BusSender.Core.Tests/BusSenderServiceTests.cs
+++ b/tests/Equinor.ProCoSys.BusSender.Core.Tests/BusSenderServiceTests.cs
@@ -25,7 +25,7 @@ public class BusSenderServiceTests
 {
     private Mock<IBusEventRepository> _busEventRepository;
     private List<BusEvent> _busEvents;
-    private Mock<BusEventService> _busEventServiceMock;
+    private Mock<IBusEventService> _busEventServiceMock;
     private PcsBusSender _busSender;
     private Mock<IEventRepository> _dapperRepositoryMock;
     private BusSenderService _dut;
@@ -97,7 +97,7 @@ public class BusSenderServiceTests
 
         _dapperRepositoryMock = new Mock<IEventRepository>();
         _busEventServiceMock = new Mock<BusEventService>(_tagDetailsRepositoryMock.Object, _dapperRepositoryMock.Object)
-            { CallBase = true };
+            { CallBase = true }.As<IBusEventService>();
         _iUnitOfWork = new Mock<IUnitOfWork>();
 
         _busEventRepository.Setup(b => b.GetEarliestUnProcessedEventChunk()).Returns(() => Task.FromResult(_busEvents));
@@ -387,7 +387,6 @@ public class BusSenderServiceTests
 
         _busEventServiceMock.Setup(b => b.AttachTagDetails(It.IsAny<string>()))
             .Returns(() => Task.FromResult("{}"));
-
         // Act
         await _dut.HandleBusEvents();
 

--- a/tests/Equinor.ProCoSys.BusSender.Core.Tests/BusSenderServiceTests.cs
+++ b/tests/Equinor.ProCoSys.BusSender.Core.Tests/BusSenderServiceTests.cs
@@ -375,7 +375,7 @@ public class BusSenderServiceTests
             busEvents.Add(new BusEvent
             {
                 Event = TagTopic.TopicName,
-                Message = $"Message {i}",
+                Message = $"{{ \"TagId\": \"{i}\" }}",
                 Status = Status.UnProcessed
             });
         }
@@ -385,7 +385,7 @@ public class BusSenderServiceTests
         _busEventRepository.Setup(b => b.GetEarliestUnProcessedEventChunk())
             .Returns(() => Task.FromResult(busEvents));
 
-        _busEventServiceMock.Setup(b => b.AttachTagDetails(It.IsAny<string>()))
+        _busEventServiceMock.Setup(b => b.AttachTagDetails(It.IsAny<BusEvent>()))
             .Returns(() => Task.FromResult("{}"));
         // Act
         await _dut.HandleBusEvents();
@@ -394,7 +394,7 @@ public class BusSenderServiceTests
         Assert.AreEqual(1001, busEvents.Count);
         Assert.IsTrue(busEvents.All(be => be.Event == TagTopic.TopicName));
         _busEventServiceMock.Verify(
-            t => t.AttachTagDetails(It.IsAny<string>()), Times.AtLeastOnce());
+            t => t.AttachTagDetails(It.IsAny<BusEvent>()), Times.AtLeastOnce());
     }
 
     [TestMethod]


### PR DESCRIPTION
When all events in a chunk of type tag and the chunk size is lower than or equal to 1000 details from the database is executed in one go for all of them.
https://github.com/equinor/cc-toolbox/issues/1676