### PR TITLE
chore: clean up program class

### DIFF
--- a/src/Equinor.ProCoSys.BusSender.Worker/TopicNameConstants.cs
+++ b/src/Equinor.ProCoSys.BusSender.Worker/TopicNameConstants.cs
@@ -1,0 +1,57 @@
+﻿using System.Collections.Generic;
+
+namespace Equinor.ProCoSys.BusSender.Worker;
+
+public class TopicNameConstants
+{
+    public static List<string> TopicNames { get; } =
+    [
+        "tagequipment",
+        "swcrattachment",
+        "swcrotherreference",
+        "swcrtype",
+        "action",
+        "task",
+        "commpkgtask",
+        "commpkg",
+        "mcpkg",
+        "wo",
+        "person",
+        "project",
+        "responsible",
+        "tagfunction",
+        "tag",
+        "punchlistitem",
+        "library",
+        "checklist",
+        "milestone",
+        "wocutoff",
+        "swcr",
+        "swcrsignature",
+        "query",
+        "querysignature",
+        "certificate",
+        "wochecklist",
+        "womaterial",
+        "womilestone",
+        "stock",
+        "piperevision",
+        "document",
+        "pipingspool",
+        "commpkgoperation",
+        "loopcontent",
+        "commpkgquery",
+        "calloff",
+        "heattrace",
+        "libraryfield",
+        "mcpkgmilestone",
+        "commpkgmilestone",
+        "heattracepipetest",
+        "notification",
+        "notificationworkorder",
+        "punchprioritylibraryrelation",
+        "punchlistitemattachment",
+        "notificationcommpkg",
+        "notificationsignature"
+    ];
+}

--- a/src/Equinor.ProCoSys.BusSender.Worker/appsettings.json
+++ b/src/Equinor.ProCoSys.BusSender.Worker/appsettings.json
@@ -10,6 +10,5 @@
   "ConnectionString": "#{ProcosysDb}",
   "ServiceBusConnectionString": "#{ServiceBusConnectionString}",
   "MessageChunkSize": 30,
-  "TimerInterval": "#{TimerInterval}",
-  "TopicNames": "tagequipment,swcrattachment,swcrotherreferences,swcrtype,commpkg,mcpkg,person,project,responsible,tagfunction,tag,punchlistitem,library,checklist,milestone,wocutoff,swcr,swcrsignature,query,querysignature,certificate,wo,wochecklist,womaterial,womilestone,stock,piperevision,document,pipingspool,commpkgoperation,loopcontent,commpkgquery,calloff,heattrace,libraryfield"
+  "TimerInterval": "#{TimerInterval}"
 }


### PR DESCRIPTION
remove dead paths for appconfig setup.
if we want it to run without appconfig, we will have to set it up, but it is currently not supported. 

Move topic names out of appConfig. 
Since staring on this project I've updated the config at runtime 0 times.
There have however been at least 10+ instances of the app going down because we've not added the topics to the config in some of the environments.

Test and Prod should follow the code, and do not need to differentiate. Dev is dead afaik.